### PR TITLE
Chatops Stream Ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ gem "lita-stackstorm"
 
 * `auth_port` (Integer) – Port used for Authentication. Defaults to `9101`.
 * `execution_port` (Integer) – Port for executions. Defaults to `9100`.
+* `emoji_icon` (Integer) – Emoji used when bot injests event stream. Defaults to `:panda:`.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lita-stackstorm [![Gem Version](https://badge.fury.io/rb/lita-stackstorm.svg)](http://badge.fury.io/rb/lita-stackstorm) **BETA**
+# lita-stackstorm [![Gem Version](https://badge.fury.io/rb/lita-stackstorm.svg)](http://badge.fury.io/rb/lita-stackstorm)
 
 **lita-stackstorm** is an handler for [Lita](https://www.lita.io) that allows your bot to interact with your stackstorm installation via st2api.
 

--- a/lib/lita/handlers/stackstorm.rb
+++ b/lib/lita/handlers/stackstorm.rb
@@ -155,7 +155,6 @@ module Lita
             command['formats'].each do |format|
               f = format.gsub(/(\s*){{\s*\S+\s*=\s*(?:({.+?}|.+?))\s*}}(\s*)/, '\\s*([\\S]+)?\\s*')
               f = f.gsub(/\s*{{.+?}}\s*/, '\\s*([\\S]+?)\\s*')
-              puts f
               f = "^\\s*#{f}#{extra_params}\\s*$"
               redis.set(f, {format: format, object: command}.to_json)
               a+= "#{format} -> #{command['description']}\n"

--- a/lib/lita/handlers/stackstorm.rb
+++ b/lib/lita/handlers/stackstorm.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'net/http'
 
 class Array
   def swap!(a,b)
@@ -20,6 +21,8 @@ module Lita
       config :auth_port, required: false, default: 9100
       config :execution_port, required: false, default: 9101
 
+      on :connected, :stream_listen
+
       class << self
         attr_accessor :token, :expires
       end
@@ -33,6 +36,14 @@ module Lita
       route /^st2 (ls|aliases|list)$/, :list, command: false, help: { "st2 list" => "list available st2 chatops commands" }
 
       route /^!(.*)$/, :call_alias, command: false, help: {}
+
+      def stream_listen(payload)
+        target = Source.new(room: '#test-the-things')
+        robot.send_message(target, "Hello")
+        Thread.new {
+          
+        }
+      end
 
       def auth_builder
         if Integer(config.auth_port) == 443 and config.url.start_with?('https')

--- a/lib/lita/handlers/stackstorm.rb
+++ b/lib/lita/handlers/stackstorm.rb
@@ -21,6 +21,7 @@ module Lita
       config :password, required: true
       config :auth_port, required: false, default: 9100
       config :execution_port, required: false, default: 9101
+      config :emoji_icon, required: false
 
       on :connected, :stream_listen
 
@@ -44,7 +45,7 @@ module Lita
           parameters: {
             username: user,
             text: message,
-            icon_emoji:":sophicware:",
+            icon_emoji: config.emoji_icon,
             channel: channel
           }
         }

--- a/lib/lita/handlers/stackstorm.rb
+++ b/lib/lita/handlers/stackstorm.rb
@@ -21,7 +21,7 @@ module Lita
       config :password, required: true
       config :auth_port, required: false, default: 9100
       config :execution_port, required: false, default: 9101
-      config :emoji_icon, required: false
+      config :emoji_icon, required: false, default: ":panda:"
 
       on :connected, :stream_listen
 

--- a/lib/lita/handlers/stackstorm.rb
+++ b/lib/lita/handlers/stackstorm.rb
@@ -40,16 +40,22 @@ module Lita
       route /^!(.*)$/, :call_alias, command: false, help: {}
 
       def direct_post(channel, message, user)
-        payload = {
-          action: "slack.chat.postMessage",
-          parameters: {
-            username: user,
-            text: message,
-            icon_emoji: config.emoji_icon,
-            channel: channel
+        case robot.config.robot.adapter
+        when :slack
+          payload = {
+            action: "slack.chat.postMessage",
+            parameters: {
+              username: user,
+              text: message,
+              icon_emoji: config.emoji_icon,
+              channel: channel
+            }
           }
-        }
-        make_post_request("/executions", payload)
+          make_post_request("/executions", payload)
+        else
+          target = Lita::Source.new(user: user, room: Lita::Room.fuzzy_find(channel))
+          robot.send_message(target, message)
+        end
       end
 
       def stream_listen(payload)


### PR DESCRIPTION
The PR allows the bot to listen to the `/stream` endpoint for `st2.announcement` events in order to post back data injected into the event stream related to chatops. Right now it designed to work with `slack` and if slack isn't the adapter, tries to respond using `robot.send_message`.

The following optional config settings were added:

`emoji_icon`
